### PR TITLE
Update OmronD6T.cpp

### DIFF
--- a/OmronD6T.cpp
+++ b/OmronD6T.cpp
@@ -53,7 +53,7 @@ void OmronD6T::scanTemp() {
     for (int x = 0; x < 4; x++) {
       i = x + (y * 4);
       value = buf[(i * 2 + 2)] + (buf[(i * 2 + 3)] << 8);
-      temp[y][x] = value * 0.1;
+      temp[x][y] = value * 0.1;
     }
   }
 }


### PR DESCRIPTION
Whether x or y comes first is swapped in the example vs the library.  If y is first than the 16 values in the array match the order of the data from the buffer (assuming all 16 values in the array are contiguous), but if x comes first, it makes things more useable since in math x always comes before y.  I went with X first.